### PR TITLE
Remote loop overrides

### DIFF
--- a/app.js
+++ b/app.js
@@ -119,6 +119,7 @@ function create (env, ctx) {
   ///////////////////////////////////////////////////
   var api = require('./lib/api/')(env, ctx);
   var ddata = require('./lib/data/endpoints')(env, ctx);
+  var notificationsV2 = require('./lib/api/notifications-v2')(app, ctx)
 
   app.use(compression({
     filter: function shouldCompress (req, res) {
@@ -171,6 +172,7 @@ function create (env, ctx) {
   app.use('/api/v2/properties', ctx.properties);
   app.use('/api/v2/authorization', ctx.authorization.endpoints);
   app.use('/api/v2/ddata', ddata);
+  app.use('/api/v2/notifications', notificationsV2);
 
   // pebble data
   app.get('/pebble', ctx.pebble);

--- a/app.js
+++ b/app.js
@@ -169,6 +169,10 @@ function create (env, ctx) {
     limit: 1048576 * 50
   }), api);
 
+  app.use('/api/v2', bodyParser({
+    limit: 1048576 * 50
+  }), api);
+
   app.use('/api/v2/properties', ctx.properties);
   app.use('/api/v2/authorization', ctx.authorization.endpoints);
   app.use('/api/v2/ddata', ddata);

--- a/lib/api/index.js
+++ b/lib/api/index.js
@@ -54,7 +54,7 @@ function create (env, ctx) {
   app.all('/notifications*', require('./notifications-api')(app, wares, ctx));
 
   app.all('/activity*', require('./activity/')(app, wares, ctx));
-  
+
   app.use('/', wares.sendJSONStatus, require('./verifyauth')(ctx));
   app.all('/food*', require('./food/')(app, wares, ctx));
 

--- a/lib/api/notifications-api.js
+++ b/lib/api/notifications-api.js
@@ -13,6 +13,17 @@ function configure (app, wares, ctx) {
     }
   });
 
+  api.post('/notifications/loop', ctx.authorization.isPermitted('notifications:loop:push'), function (req, res) {
+    ctx.loop.sendNotification(req.body, function (error) {
+      if (error) {
+        res.sendStatus(500);
+        console.log("error sending notification to Loop: ", error);
+      } else {
+        res.sendStatus(200);
+      }
+    });
+  });
+
   if (app.enabled('api')) {
     // Create and store new sgv entries
     api.get('/notifications/ack', ctx.authorization.isPermitted('notifications:*:ack'), function (req, res) {

--- a/lib/api/notifications-api.js
+++ b/lib/api/notifications-api.js
@@ -13,17 +13,6 @@ function configure (app, wares, ctx) {
     }
   });
 
-  api.post('/notifications/loop', ctx.authorization.isPermitted('notifications:loop:push'), function (req, res) {
-    ctx.loop.sendNotification(req.body, req.connection.remoteAddress, function (error) {
-      if (error) {
-        res.sendStatus(500);
-        console.log("error sending notification to Loop: ", error);
-      } else {
-        res.sendStatus(200);
-      }
-    });
-  });
-
   if (app.enabled('api')) {
     // Create and store new sgv entries
     api.get('/notifications/ack', ctx.authorization.isPermitted('notifications:*:ack'), function (req, res) {

--- a/lib/api/notifications-api.js
+++ b/lib/api/notifications-api.js
@@ -14,7 +14,7 @@ function configure (app, wares, ctx) {
   });
 
   api.post('/notifications/loop', ctx.authorization.isPermitted('notifications:loop:push'), function (req, res) {
-    ctx.loop.sendNotification(req.body, function (error) {
+    ctx.loop.sendNotification(req.body, req.connection.remoteAddress, function (error) {
       if (error) {
         res.sendStatus(500);
         console.log("error sending notification to Loop: ", error);

--- a/lib/api/notifications-v2.js
+++ b/lib/api/notifications-v2.js
@@ -6,9 +6,6 @@ function configure (app, ctx) {
     ;
 
   api.post('/loop', ctx.authorization.isPermitted('notifications:loop:push'), function (req, res) {
-    console.log("req = ", req);
-    console.log("req.connection.remoteAddress = ", req.connection.remoteAddress);
-    console.log("req.body = ", req.body);
     ctx.loop.sendNotification(req.body, req.connection.remoteAddress, function (error) {
       if (error) {
         res.sendStatus(500);

--- a/lib/api/notifications-v2.js
+++ b/lib/api/notifications-v2.js
@@ -1,0 +1,24 @@
+'use strict';
+
+function configure (app, ctx) {
+  var express = require('express')
+    , api = express.Router( )
+    ;
+
+  api.post('/loop', ctx.authorization.isPermitted('notifications:loop:push'), function (req, res) {
+    console.log("req = ", req);
+    console.log("req.connection.remoteAddress = ", req.connection.remoteAddress);
+    console.log("req.body = ", req.body);
+    ctx.loop.sendNotification(req.body, req.connection.remoteAddress, function (error) {
+      if (error) {
+        res.sendStatus(500);
+        console.log("error sending notification to Loop: ", error);
+      } else {
+        res.sendStatus(200);
+      }
+    });
+  });
+
+  return api;
+}
+module.exports = configure;

--- a/lib/api/verifyauth.js
+++ b/lib/api/verifyauth.js
@@ -22,4 +22,3 @@ function configure (ctx) {
 }
 
 module.exports = configure;
-

--- a/lib/client/careportal.js
+++ b/lib/client/careportal.js
@@ -399,7 +399,7 @@ function init (client, $) {
       if (window.confirm(buildConfirmText(data))) {
         var submitHook = submitHooks[data.eventType];
         if (submitHook) {
-          submitHook(data, function (error) {
+          submitHook(client, data, function (error) {
             if (error) {
               alert(translate('Submitting treatment failed') + '. ' + translate('Error') + ': ' + error);
             }

--- a/lib/client/careportal.js
+++ b/lib/client/careportal.js
@@ -13,12 +13,6 @@ function init (client, $) {
   var storage = Storages.localStorage;
   var units = client.settings.units;
 
-  careportal.allEventTypes = client.plugins.getAllEventTypes(client.sbx);
-
-  careportal.events = _.map(careportal.allEventTypes, function each (event) {
-    return _.pick(event, ['val', 'name']);
-  });
-
   var eventTime = $('#eventTimeValue');
   var eventDate = $('#eventDateValue');
 
@@ -43,16 +37,31 @@ function init (client, $) {
     }
   }
 
+  function refreshEventTypes() {
+    careportal.allEventTypes = client.plugins.getAllEventTypes(client.sbx);
+
+    careportal.events = _.map(careportal.allEventTypes, function each (event) {
+      return _.pick(event, ['val', 'name']);
+    });
+  }
+
   var inputMatrix = {};
   var presubmitHooks = {};
 
-  _.forEach(careportal.allEventTypes, function each (event) {
-    inputMatrix[event.val] = _.pick(event, ['bg', 'insulin', 'carbs', 'protein', 'fat', 'prebolus', 'duration', 'percent', 'absolute', 'profile', 'split', 'reasons', 'targets']);
-    presubmitHooks[event.val] = event.presubmitHook;
-  });
+  refreshEventTypes();
 
   careportal.filterInputs = function filterInputs (event) {
     var eventType = $('#eventType').val();
+
+    refreshEventTypes();
+
+    inputMatrix = {};
+    presubmitHooks = {};
+
+    _.forEach(careportal.allEventTypes, function each (event) {
+      inputMatrix[event.val] = _.pick(event, ['bg', 'insulin', 'carbs', 'protein', 'fat', 'prebolus', 'duration', 'percent', 'absolute', 'profile', 'split', 'reasons', 'targets']);
+      presubmitHooks[event.val] = event.presubmitHook;
+    });
 
     function displayType (enabled) {
       if (enabled) {
@@ -86,7 +95,7 @@ function init (client, $) {
 
     $('#reason').empty();
     _.each(reasons, function eachReason (reason) {
-      $('#reason').append('<option value="' + reason.name + '">' + translate(reason.name) + '</option>');
+      $('#reason').append('<option value="' + reason.name + '">' + translate(reason.displayName || reason.name) + '</option>');
     });
 
     careportal.reasonable();
@@ -198,11 +207,14 @@ function init (client, $) {
   };
 
   function gatherData () {
+    var eventType = $('#eventType').val();
+    var selectedReason = $('#reason').val();
+
     var data = {
       enteredBy: $('#enteredBy').val()
-      , eventType: $('#eventType').val()
+      , eventType: eventType
       , glucose: $('#glucoseValue').val().replace(',', '.')
-      , reason: $('#reason').val()
+      , reason: selectedReason
       , targetTop: $('#targetTop').val().replace(',', '.')
       , targetBottom: $('#targetBottom').val().replace(',', '.')
       , glucoseType: $('#treatment-form').find('input[name=glucoseType]:checked').val()
@@ -217,6 +229,12 @@ function init (client, $) {
       , notes: $('#notes').val()
       , units: client.settings.units
     };
+
+    var reasons = inputMatrix[eventType]['reasons'];
+    var reason = _.find(reasons, function matches (r) {
+      return r.name === selectedReason;
+    });
+    data.reasonDisplay = reason.displayName;
 
     if (units == "mmol") {
       data.targetTop = data.targetTop * 18;

--- a/lib/client/careportal.js
+++ b/lib/client/careportal.js
@@ -37,23 +37,15 @@ function init (client, $) {
     }
   }
 
+  var inputMatrix = {};
+  var presubmitHooks = {};
+
   function refreshEventTypes() {
     careportal.allEventTypes = client.plugins.getAllEventTypes(client.sbx);
 
     careportal.events = _.map(careportal.allEventTypes, function each (event) {
       return _.pick(event, ['val', 'name']);
     });
-  }
-
-  var inputMatrix = {};
-  var presubmitHooks = {};
-
-  refreshEventTypes();
-
-  careportal.filterInputs = function filterInputs (event) {
-    var eventType = $('#eventType').val();
-
-    refreshEventTypes();
 
     inputMatrix = {};
     presubmitHooks = {};
@@ -62,6 +54,12 @@ function init (client, $) {
       inputMatrix[event.val] = _.pick(event, ['bg', 'insulin', 'carbs', 'protein', 'fat', 'prebolus', 'duration', 'percent', 'absolute', 'profile', 'split', 'reasons', 'targets']);
       presubmitHooks[event.val] = event.presubmitHook;
     });
+  }
+
+  refreshEventTypes();
+
+  careportal.filterInputs = function filterInputs (event) {
+    var eventType = $('#eventType').val();
 
     function displayType (enabled) {
       if (enabled) {
@@ -183,6 +181,8 @@ function init (client, $) {
   };
 
   careportal.prepare = function prepare () {
+    refreshEventTypes();
+
     $('#profile').empty();
     client.profilefunctions.listBasalProfiles().forEach(function(p) {
       $('#profile').append('<option val="' + p + '">' + p + '</option>');

--- a/lib/client/careportal.js
+++ b/lib/client/careportal.js
@@ -38,7 +38,7 @@ function init (client, $) {
   }
 
   var inputMatrix = {};
-  var presubmitHooks = {};
+  var submitHooks = {};
 
   function refreshEventTypes() {
     careportal.allEventTypes = client.plugins.getAllEventTypes(client.sbx);
@@ -48,11 +48,11 @@ function init (client, $) {
     });
 
     inputMatrix = {};
-    presubmitHooks = {};
+    submitHooks = {};
 
     _.forEach(careportal.allEventTypes, function each (event) {
       inputMatrix[event.val] = _.pick(event, ['bg', 'insulin', 'carbs', 'protein', 'fat', 'prebolus', 'duration', 'percent', 'absolute', 'profile', 'split', 'reasons', 'targets']);
-      presubmitHooks[event.val] = event.presubmitHook;
+      submitHooks[event.val] = event.submitHook;
     });
   }
 
@@ -234,7 +234,10 @@ function init (client, $) {
     var reason = _.find(reasons, function matches (r) {
       return r.name === selectedReason;
     });
-    data.reasonDisplay = reason.displayName;
+
+    if (reason) {
+      data.reasonDisplay = reason.displayName;
+    }
 
     if (units == "mmol") {
       data.targetTop = data.targetTop * 18;
@@ -394,17 +397,16 @@ function init (client, $) {
       window.alert(messages);
     } else {
       if (window.confirm(buildConfirmText(data))) {
-        var presubmitHook = presubmitHooks[data.eventType];
-        if (presubmitHook) {
-          presubmitHook(data, function (error) {
+        var submitHook = submitHooks[data.eventType];
+        if (submitHook) {
+          submitHook(data, function (error) {
             if (error) {
-              alert(translate('Entering record failed') + '. ' + translate('Error') + ': ' + error);
-            } else {
-              postTreatment(data);
+              alert(translate('Submitting treatment failed') + '. ' + translate('Error') + ': ' + error);
             }
           });
+        } else {
+          postTreatment(data);
         }
-        postTreatment(data);
       }
     }
   }

--- a/lib/client/careportal.js
+++ b/lib/client/careportal.js
@@ -44,9 +44,11 @@ function init (client, $) {
   }
 
   var inputMatrix = {};
+  var presubmitHooks = {};
 
   _.forEach(careportal.allEventTypes, function each (event) {
     inputMatrix[event.val] = _.pick(event, ['bg', 'insulin', 'carbs', 'protein', 'fat', 'prebolus', 'duration', 'percent', 'absolute', 'profile', 'split', 'reasons', 'targets']);
+    presubmitHooks[event.val] = event.presubmitHook;
   });
 
   careportal.filterInputs = function filterInputs (event) {
@@ -374,6 +376,16 @@ function init (client, $) {
       window.alert(messages);
     } else {
       if (window.confirm(buildConfirmText(data))) {
+        var presubmitHook = presubmitHooks[data.eventType];
+        if (presubmitHook) {
+          presubmitHook(data, function (error) {
+            if (error) {
+              alert(translate('Entering record failed') + '. ' + translate('Error') + ': ' + error);
+            } else {
+              postTreatment(data);
+            }
+          });
+        }
         postTreatment(data);
       }
     }

--- a/lib/client/renderer.js
+++ b/lib/client/renderer.js
@@ -358,7 +358,7 @@ function init (client, d3) {
         if (d.eventType === 'Temporary Target') {
           return '';
         }
-        return d.notes || d.eventType;
+        return d.notes || d.reason || d.eventType;
       });
   };
 

--- a/lib/client/renderer.js
+++ b/lib/client/renderer.js
@@ -181,6 +181,38 @@ function init (client, d3) {
         targetTop = Math.round(targetTop / 18.0 * 10) / 10;
       }
 
+      var correctionRangeText;
+      if (d.correctionRange) {
+        var min = d.correctionRange[0];
+        var max = d.correctionRange[1];
+
+        if (client.settings.units === 'mmol') {
+          max = client.sbx.roundBGToDisplayFormat(client.sbx.scaleMgdl(max));
+          min = client.sbx.roundBGToDisplayFormat(client.sbx.scaleMgdl(min));
+        }
+
+        if (d.correctionRange[0] === d.correctionRange[1]) {
+          correctionRangeText = '' + min;
+        } else {
+          correctionRangeText = '' + min + ' - ' + max;
+        }
+      }
+
+      var durationText;
+      if (d.duration) {
+        var durationMinutes = Math.round(d.duration);
+        if (durationMinutes > 0 && durationMinutes % 60 == 0) {
+          var durationHours = durationMinutes / 60;
+          if (durationHours > 1) {
+            durationText = durationHours + ' hours';
+          } else {
+            durationText = durationHours + ' hour';
+          }
+        } else {
+          durationText = durationMinutes + ' min';
+        }
+      }
+
       return '<strong>' + translate('Time') + ':</strong> ' + client.formatTime(new Date(d.mills)) + '<br/>' +
         (d.eventType ? '<strong>' + translate('Treatment type') + ':</strong> ' + translate(client.careportal.resolveEventName(d.eventType)) + '<br/>' : '') +
         (d.reason ? '<strong>' + translate('Reason') + ':</strong> ' + translate(d.reason) + '<br/>' : '') +
@@ -188,7 +220,9 @@ function init (client, d3) {
         (d.enteredBy ? '<strong>' + translate('Entered By') + ':</strong> ' + d.enteredBy + '<br/>' : '') +
         (d.targetTop ? '<strong>' + translate('Target Top') + ':</strong> ' + targetTop + '<br/>' : '') +
         (d.targetBottom ? '<strong>' + translate('Target Bottom') + ':</strong> ' + targetBottom + '<br/>' : '') +
-        (d.duration ? '<strong>' + translate('Duration') + ':</strong> ' + Math.round(d.duration) + ' min<br/>' : '') +
+        (durationText ? '<strong>' + translate('Duration') + ':</strong> ' + durationText + '<br/>' : '') +
+        (d.insulinNeedsScaleFactor ? '<strong>' + translate('Insulin Scale Factor') + ':</strong> ' + d.insulinNeedsScaleFactor * 100 + '%<br/>' : '') +
+        (correctionRangeText ? '<strong>' + translate('Correction Range') + ':</strong> ' + correctionRangeText + '<br/>' : '') +
         (d.notes ? '<strong>' + translate('Notes') + ':</strong> ' + d.notes : '');
     }
 

--- a/lib/plugins/loop.js
+++ b/lib/plugins/loop.js
@@ -182,9 +182,23 @@ function init (ctx) {
     var client = Nightscout.client;
 
     var reasonconf = [];
-    // TODO: Fetch list from presets stored in settings
-    // Nightscout.client.sbx.data.profile.data[0]
-    reasonconf.push({ name: translate('🏃Recess')});
+
+    if (sbx.data === undefined || sbx.data.profile === undefined || sbx.data.profile.data.length == 0) {
+      return [];
+    }
+
+    let profile = sbx.data.profile.data[0];
+
+    if (profile.loopSettings === undefined || profile.loopSettings.overridePresets == undefined) {
+      return [];
+    }
+
+    let presets = profile.loopSettings.overridePresets;
+
+    for (var i = 0; i < presets.length; i++) {
+      let preset = presets[i]
+      reasonconf.push({ name: preset.name, displayName: preset.symbol + " " + preset.name});
+    }
 
     var presubmitHook = function temporaryScheduleOverridePresubmit (data, callback) {
       console.log("Submitting override", data);

--- a/lib/plugins/loop.js
+++ b/lib/plugins/loop.js
@@ -197,11 +197,10 @@ function init (ctx) {
 
     for (var i = 0; i < presets.length; i++) {
       let preset = presets[i]
-      reasonconf.push({ name: preset.name, displayName: preset.symbol + " " + preset.name});
+      reasonconf.push({ name: preset.name, displayName: preset.symbol + " " + preset.name, duration: preset.duration / 60});
     }
 
-    var presubmitHook = function temporaryScheduleOverridePresubmit (data, callback) {
-      console.log("Submitting override", data);
+    var postLoopNotification = function (data, callback) {
 
       $.ajax({
         method: "POST"
@@ -209,7 +208,7 @@ function init (ctx) {
         , url: '/api/v1/notifications/loop'
         , data: data
       })
-      .done(callback)
+      .done()
       .fail(callback);
     }
 
@@ -228,7 +227,7 @@ function init (ctx) {
         , split: false
         , targets: false
         , reasons: reasonconf
-        , presubmitHook: presubmitHook
+        , submitHook: postLoopNotification
       },
       {
         val: 'Temporary Override Cancel'
@@ -243,7 +242,7 @@ function init (ctx) {
         , profile: false
         , split: false
         , targets: false
-        , presubmitHook: presubmitHook
+        , submitHook: postLoopNotification
       }
     ];
   };

--- a/lib/plugins/loop.js
+++ b/lib/plugins/loop.js
@@ -16,7 +16,6 @@ function init (ctx) {
     , pluginType: 'pill-status'
   };
 
-  var translate = ctx.language.translate;
   var firstPrefs = true;
 
   loop.getPrefs = function getPrefs (sbx) {

--- a/lib/plugins/loop.js
+++ b/lib/plugins/loop.js
@@ -178,8 +178,6 @@ function init (ctx) {
     var units = sbx.settings.units;
     console.log('units', units);
 
-    var client = Nightscout.client;
-
     var reasonconf = [];
 
     if (sbx.data === undefined || sbx.data.profile === undefined || sbx.data.profile.data.length == 0) {
@@ -199,7 +197,7 @@ function init (ctx) {
       reasonconf.push({ name: preset.name, displayName: preset.symbol + " " + preset.name, duration: preset.duration / 60});
     }
 
-    var postLoopNotification = function (data, callback) {
+    var postLoopNotification = function (client, data, callback) {
 
       $.ajax({
         method: "POST"

--- a/lib/plugins/loop.js
+++ b/lib/plugins/loop.js
@@ -202,7 +202,7 @@ function init (ctx) {
       $.ajax({
         method: "POST"
         , headers: client.headers()
-        , url: '/api/v1/notifications/loop'
+        , url: '/api/v2/notifications/loop'
         , data: data
       })
       .done()

--- a/lib/plugins/loop.js
+++ b/lib/plugins/loop.js
@@ -16,6 +16,7 @@ function init (ctx) {
     , pluginType: 'pill-status'
   };
 
+  var translate = ctx.language.translate;
   var firstPrefs = true;
 
   loop.getPrefs = function getPrefs (sbx) {
@@ -173,6 +174,66 @@ function init (ctx) {
     }
   };
 
+  loop.getEventTypes = function getEventTypes (sbx) {
+
+    var units = sbx.settings.units;
+    console.log('units', units);
+
+    var client = Nightscout.client;
+
+    var reasonconf = [];
+    // TODO: Fetch list from presets stored in settings
+    // Nightscout.client.sbx.data.profile.data[0]
+    reasonconf.push({ name: translate('🏃Recess')});
+
+    var presubmitHook = function temporaryScheduleOverridePresubmit (data, callback) {
+      console.log("Submitting override", data);
+
+      $.ajax({
+        method: "POST"
+        , headers: client.headers()
+        , url: '/api/v1/notifications/loop'
+        , data: data
+      })
+      .done(callback)
+      .fail(callback);
+    }
+
+    return [
+      {
+        val: 'Temporary Override'
+        , name: 'Temporary Override'
+        , bg: false
+        , insulin: false
+        , carbs: false
+        , prebolus: false
+        , duration: true
+        , percent: false
+        , absolute: false
+        , profile: false
+        , split: false
+        , targets: false
+        , reasons: reasonconf
+        , presubmitHook: presubmitHook
+      },
+      {
+        val: 'Temporary Override Cancel'
+        , name: 'Temporary Override Cancel'
+        , bg: false
+        , insulin: false
+        , carbs: false
+        , prebolus: false
+        , duration: false
+        , percent: false
+        , absolute: false
+        , profile: false
+        , split: false
+        , targets: false
+        , presubmitHook: presubmitHook
+      }
+    ];
+  };
+
   loop.updateVisualisation = function updateVisualisation (sbx) {
     var prop = sbx.properties.loop;
 
@@ -284,9 +345,9 @@ function init (ctx) {
         var iob = prop.lastLoop.iob;
         valueParts = valueParts.concat([
           ', IOB: '
-          
+
           , sbx.roundInsulinForDisplayFormat(iob.iob) + 'U'
-          
+
           , iob.basaliob ? ', Basal IOB ' + sbx.roundInsulinForDisplayFormat(iob.basaliob) + 'U' : ''
         ]);
       }

--- a/lib/server/bootevent.js
+++ b/lib/server/bootevent.js
@@ -7,8 +7,8 @@ var UPDATE_THROTTLE = 5000;
 function boot (env, language) {
 
   //////////////////////////////////////////////////
-  // Check Node version. 
-  // Latest Node 8 LTS and Latest Node 10 LTS are recommended and supported. 
+  // Check Node version.
+  // Latest Node 8 LTS and Latest Node 10 LTS are recommended and supported.
   // Latest Node version on Azure is tolerated, but not recommended
   // Latest Node (non LTS) version works, but is not recommended
   // Older Node versions or Node versions with known security issues will not work.
@@ -34,7 +34,7 @@ function boot (env, language) {
     else if ( semver.eq(nodeVersion, '10.15.2')) {
       //Latest Node version on Azure is tolerated, but not recommended
       console.log('WARNING: Node version v10.15.2 and Microsoft Azure are not recommended.');
-      console.log('WARNING: Please migrate to another hosting provider. Your Node version is outdated and insecure'); 
+      console.log('WARNING: Please migrate to another hosting provider. Your Node version is outdated and insecure');
       next();
     }
     else if ( semver.satisfies(nodeVersion, '^12.6.0')) {
@@ -42,7 +42,7 @@ function boot (env, language) {
         console.debug('Node version ' + nodeVersion + ' is not a LTS version. Not recommended. Not supported');
         next();
     } else {
-      // Other versions will not start 
+      // Other versions will not start
       console.log( 'ERROR: Node version ' + nodeVersion + ' is not supported. Please use a secure LTS version or upgrade your Node');
       process.exit(1);
     }
@@ -164,6 +164,7 @@ function boot (env, language) {
     ctx.pushover = require('../plugins/pushover')(env);
     ctx.maker = require('../plugins/maker')(env);
     ctx.pushnotify = require('./pushnotify')(env, ctx);
+    ctx.loop = require('./loop')(env, ctx);
 
     ctx.activity = require('./activity')(env, ctx);
     ctx.entries = require('./entries')(env, ctx);

--- a/lib/server/loop.js
+++ b/lib/server/loop.js
@@ -9,7 +9,7 @@ function init (env, ctx) {
     return loop;
   }
 
-  loop.sendNotification = function sendNotification (data, completionHandler) {
+  loop.sendNotification = function sendNotification (data, remoteAddress, completionHandler) {
     console.info('loop notify: ', data);
     console.info('data.eventType: ', data.eventType);
     console.info('ctx.ddata.profiles: ', ctx.ddata.profiles);
@@ -42,22 +42,25 @@ function init (env, ctx) {
       return;
     }
 
-    if (data.eventType != 'Temporary Override') {
+    var payload = {'remote-address': remoteAddress};
+    var alert;
+    if (data.eventType === 'Temporary Override Cancel') {
+      payload["cancel-temporary-override"] = "true";
+      alert = "Cancel Temporary Override";
+    } else if (data.eventType === 'Temporary Override') {
+      payload["override-name"] = data.reason;
+      alert = data.reasonDisplay + " Temporary Override";
+    } else {
       completion("Loop notification failed: Unhandled event type:", data.eventType);
       return;
     }
 
-    // {"aps":{"timestamp": "2019-09-17T22:55:50Z", "alert":"🏃Recess Override Enacted","content-available": 1,"override-name":"Recess", "override-duration-minutes": 120.0}}
-
-
     let notification = new apn.Notification();
-    notification.alert = data.reasonDisplay + " Temporary Override";
+    notification.alert = alert;
     notification.topic = loopSettings.bundleIdentifier;
     notification.contentAvailable = 1;
     notification.expiry =  Math.round((Date.now() + 60 * 5) / 1000); // Allow this to enact within 5 minutes.
-    notification.payload = {
-      "override-name": data.reason,
-    };
+    notification.payload = payload;
 
     if (data.duration && parseInt(data.duration) > 0) {
       notification.payload["override-duration-minutes"] = parseInt(data.duration);

--- a/lib/server/loop.js
+++ b/lib/server/loop.js
@@ -29,7 +29,7 @@ function init (env, ctx) {
       completion("Loop notification failed: Could not find loopSettings in profile.");
       return;
     }
-    
+
     let loopSettings = ctx.ddata.profiles[0].loopSettings;
 
     if (loopSettings.deviceToken === undefined) {
@@ -41,19 +41,34 @@ function init (env, ctx) {
       completion("Loop notification failed: Could not find bundleIdentifier in loopSettings.");
       return;
     }
-    //var data = sbx.data;
+
+    if (data.eventType != 'Temporary Override') {
+      completion("Loop notification failed: Unhandled event type:", data.eventType);
+      return;
+    }
+
+    // {"aps":{"timestamp": "2019-09-17T22:55:50Z", "alert":"🏃Recess Override Enacted","content-available": 1,"override-name":"Recess", "override-duration-minutes": 120.0}}
 
 
     let notification = new apn.Notification();
-    notification.alert = "Remote Override Test";
-    notification.badge = 1;
+    notification.alert = data.reasonDisplay + " Temporary Override";
     notification.topic = loopSettings.bundleIdentifier;
+    notification.contentAvailable = 1;
+    notification.expiry =  Math.round((Date.now() + 60 * 5) / 1000); // Allow this to enact within 5 minutes.
+    notification.payload = {
+      "override-name": data.reason,
+    };
+
+    if (data.duration && data.duration > 0) {
+      notification.payload["override-duration-minutes"] = data.duration;
+    }
 
     provider.send(notification, [loopSettings.deviceToken]).then( (response) => {
       if (response.sent && response.sent.length > 0) {
         completionHandler();
       } else {
-        completionHandler("APNs delivery failed.");
+        console.log("APNs delivery failed:", response.failed)
+        completionHandler("APNs delivery failed:" + response.failed);
       }
     });
   };

--- a/lib/server/loop.js
+++ b/lib/server/loop.js
@@ -1,0 +1,47 @@
+'use strict';
+
+const _ = require('lodash');
+const apn = require('apn');
+
+function init (env, ctx) {
+
+  function loop () {
+    return loop;
+  }
+
+  loop.sendNotification = function sendNotification (data, completionHandler) {
+    console.info('loop notify: ', data);
+    completionHandler();
+  };
+
+  // var pushNotificationToLoop = function () {
+  //   // api.development.push.apple.com:443
+  //   // api.push.apple.com:443
+  //   var server = 'https://api.development.push.apple.com:443';
+  //   var deviceToken = 'ee24b4e867cbf0f49af3cb0e45879075b7e6adae881ec21efe245941eb77f412';
+  //   var bundleId = 'com.UY678SP37Q.loopkit.Loop';
+  //
+  //   const client = http2.connect(server);
+  //   client.on('error', (err) => console.error(err));
+  //   const req = client.request({ ':path': '/3/device/' + deviceToken, ':method': 'POST' });
+  //   req.on('response', (headers, flags) => {
+  //     for (const name in headers) {
+  //       console.log(`${name}: ${headers[name]}`);
+  //     }
+  //   });
+  //
+  //   req.setEncoding('utf8');
+  //   let data = '';
+  //   req.on('data', (chunk) => { data += chunk; });
+  //   req.on('end', () => {
+  //     console.log(`\n${data}`);
+  //     client.close();
+  //   });
+  //   req.end();
+  // }
+
+
+  return loop();
+}
+
+module.exports = init;

--- a/lib/server/loop.js
+++ b/lib/server/loop.js
@@ -59,8 +59,8 @@ function init (env, ctx) {
       "override-name": data.reason,
     };
 
-    if (data.duration && data.duration > 0) {
-      notification.payload["override-duration-minutes"] = data.duration;
+    if (data.duration && parseInt(data.duration) > 0) {
+      notification.payload["override-duration-minutes"] = parseInt(data.duration);
     }
 
     provider.send(notification, [loopSettings.deviceToken]).then( (response) => {

--- a/lib/server/loop.js
+++ b/lib/server/loop.js
@@ -11,35 +11,52 @@ function init (env, ctx) {
 
   loop.sendNotification = function sendNotification (data, completionHandler) {
     console.info('loop notify: ', data);
-    completionHandler();
+    console.info('data.eventType: ', data.eventType);
+    console.info('ctx.ddata.profiles: ', ctx.ddata.profiles);
+
+    var options = {
+      token: {
+        key: env.extendedSettings.loop.apnsKey
+        , keyId: env.extendedSettings.loop.apnsKeyId
+        , teamId: env.extendedSettings.loop.developerTeamId
+      },
+      production: false
+    };
+
+    var provider = new apn.Provider(options);
+
+    if (ctx.ddata.profiles === undefined || ctx.ddata.profiles.length < 1 || ctx.ddata.profiles[0].loopSettings === undefined) {
+      completion("Loop notification failed: Could not find loopSettings in profile.");
+      return;
+    }
+    
+    let loopSettings = ctx.ddata.profiles[0].loopSettings;
+
+    if (loopSettings.deviceToken === undefined) {
+      completion("Loop notification failed: Could not find deviceToken in loopSettings.");
+      return;
+    }
+
+    if (loopSettings.bundleIdentifier === undefined) {
+      completion("Loop notification failed: Could not find bundleIdentifier in loopSettings.");
+      return;
+    }
+    //var data = sbx.data;
+
+
+    let notification = new apn.Notification();
+    notification.alert = "Remote Override Test";
+    notification.badge = 1;
+    notification.topic = loopSettings.bundleIdentifier;
+
+    provider.send(notification, [loopSettings.deviceToken]).then( (response) => {
+      if (response.sent && response.sent.length > 0) {
+        completionHandler();
+      } else {
+        completionHandler("APNs delivery failed.");
+      }
+    });
   };
-
-  // var pushNotificationToLoop = function () {
-  //   // api.development.push.apple.com:443
-  //   // api.push.apple.com:443
-  //   var server = 'https://api.development.push.apple.com:443';
-  //   var deviceToken = 'ee24b4e867cbf0f49af3cb0e45879075b7e6adae881ec21efe245941eb77f412';
-  //   var bundleId = 'com.UY678SP37Q.loopkit.Loop';
-  //
-  //   const client = http2.connect(server);
-  //   client.on('error', (err) => console.error(err));
-  //   const req = client.request({ ':path': '/3/device/' + deviceToken, ':method': 'POST' });
-  //   req.on('response', (headers, flags) => {
-  //     for (const name in headers) {
-  //       console.log(`${name}: ${headers[name]}`);
-  //     }
-  //   });
-  //
-  //   req.setEncoding('utf8');
-  //   let data = '';
-  //   req.on('data', (chunk) => { data += chunk; });
-  //   req.on('end', () => {
-  //     console.log(`\n${data}`);
-  //     client.close();
-  //   });
-  //   req.end();
-  // }
-
 
   return loop();
 }

--- a/lib/server/pushnotify.js
+++ b/lib/server/pushnotify.js
@@ -38,7 +38,7 @@ function init (env, ctx) {
         key = notifyToHash(notify);
       }
     }
-    
+
     notify.key = key;
 
     if (recentlySent.get(key)) {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "nightscout",
-  "version": "0.12.4",
+  "version": "0.12.5-dev",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1677,6 +1677,33 @@
         }
       }
     },
+    "apn": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/apn/-/apn-2.2.0.tgz",
+      "integrity": "sha512-YIypYzPVJA9wzNBLKZ/mq2l1IZX/2FadPvwmSv4ZeR0VH7xdNITQ6Pucgh0Uw6ZZKC+XwheaJ57DFZAhJ0FvPg==",
+      "requires": {
+        "debug": "^3.1.0",
+        "http2": "https://github.com/node-apn/node-http2/archive/apn-2.1.4.tar.gz",
+        "jsonwebtoken": "^8.1.0",
+        "node-forge": "^0.7.1",
+        "verror": "^1.10.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
+      }
+    },
     "append-transform": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/append-transform/-/append-transform-1.0.0.tgz",
@@ -2010,6 +2037,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/base64id/-/base64id-1.0.0.tgz",
       "integrity": "sha1-R2iMuZu2gE8OBtPnY7HDLlfY5rY="
+    },
+    "base64url": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/base64url/-/base64url-3.0.1.tgz",
+      "integrity": "sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A=="
     },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
@@ -2515,6 +2547,11 @@
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
       "dev": true
+    },
+    "charenc": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
+      "integrity": "sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc="
     },
     "check-types": {
       "version": "8.0.3",
@@ -3043,6 +3080,11 @@
           "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
         }
       }
+    },
+    "crypt": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
+      "integrity": "sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs="
     },
     "crypto-browserify": {
       "version": "3.12.0",
@@ -3585,6 +3627,11 @@
       "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
       "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
       "dev": true
+    },
+    "es6-promisify": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-6.0.2.tgz",
+      "integrity": "sha512-eO6vFm0JvqGzjWIQA6QVKjxpmELfhWbDUWHm1rPfIbn55mhKPiAa5xpLmQWJrNa629ZIeQ8ZvMAi13kvrjK6Mg=="
     },
     "escape-html": {
       "version": "1.0.3",
@@ -5261,6 +5308,10 @@
         "sshpk": "^1.7.0"
       }
     },
+    "http2": {
+      "version": "https://github.com/node-apn/node-http2/archive/apn-2.1.4.tar.gz",
+      "integrity": "sha512-ad4u4I88X9AcUgxCRW3RLnbh7xHWQ1f5HbrXa7gEy2x4Xgq+rq+auGx5I+nUDE2YYuqteGIlbxrwQXkIaYTfnQ=="
+    },
     "https-browserify": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
@@ -6313,6 +6364,16 @@
       "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
       "requires": {
         "object-visit": "^1.0.0"
+      }
+    },
+    "md5": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/md5/-/md5-2.2.1.tgz",
+      "integrity": "sha1-U6s41f48iJG6RlMp6iP6wFQBJvk=",
+      "requires": {
+        "charenc": "~0.0.1",
+        "crypt": "~0.0.1",
+        "is-buffer": "~1.1.1"
       }
     },
     "md5.js": {
@@ -8028,6 +8089,11 @@
         "lodash": "^4.17.15"
       }
     },
+    "node-forge": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.7.6.tgz",
+      "integrity": "sha512-sol30LUpz1jQFBjOKwbjxijiE3b6pjd74YwfD0fJOKPjF+fONKb2Yg8rYgS6+bK6VDl+/wfr4IYpC7jDzLUIfw=="
+    },
     "node-libs-browser": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.2.1.tgz",
@@ -8479,8 +8545,7 @@
     "os-tmpdir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
-      "dev": true
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
     },
     "p-defer": {
       "version": "1.0.0",
@@ -8710,6 +8775,17 @@
         "ripemd160": "^2.0.1",
         "safe-buffer": "^5.0.1",
         "sha.js": "^2.4.8"
+      }
+    },
+    "pem": {
+      "version": "1.14.3",
+      "resolved": "https://registry.npmjs.org/pem/-/pem-1.14.3.tgz",
+      "integrity": "sha512-Q+AMVMD3fzeVvZs5PHeI+pVt0hgZY2fjhkliBW43qyONLgCXPVk1ryim43F9eupHlNGLJNT5T/NNrzhUdiC5Zg==",
+      "requires": {
+        "es6-promisify": "^6.0.0",
+        "md5": "^2.2.1",
+        "os-tmpdir": "^1.0.1",
+        "which": "^1.3.1"
       }
     },
     "performance-now": {

--- a/package.json
+++ b/package.json
@@ -59,8 +59,10 @@
   "dependencies": {
     "@babel/core": "^7.5.5",
     "@babel/preset-env": "^7.5.5",
+    "apn": "^2.2.0",
     "async": "^0.9.2",
     "babel-loader": "^8.0.6",
+    "base64url": "^3.0.1",
     "body-parser": "^1.19.0",
     "bootevent": "0.0.1",
     "braces": "^3.0.2",
@@ -96,6 +98,7 @@
     "mongomock": "^0.1.2",
     "node-cache": "^4.2.1",
     "parse-duration": "^0.1.1",
+    "pem": "^1.14.3",
     "pushover-notifications": "^1.2.0",
     "random-token": "0.0.8",
     "request": "^2.88.0",


### PR DESCRIPTION
This PR adds support to Nightscout for a new Loop remote override feature. Users can use careportal (or IFTTT) to trigger a Loop override remotely.  The override will be enacted immediately, via push notification, if the Loop app is online, or if Loop gains network connectivity within 5 minutes, and the device running Loop will receive a user notification that the override has been enabled.
<img width="351" alt="careportal_entry" src="https://user-images.githubusercontent.com/14649/65898428-2ac9ea80-e377-11e9-9992-67c1d78ac365.png">
<img width="382" alt="range_and_popup" src="https://user-images.githubusercontent.com/14649/65898439-2ef60800-e377-11e9-8594-979f5718f002.png">
![override_notification](https://user-images.githubusercontent.com/14649/65898540-6664b480-e377-11e9-8004-30aafbfa1754.jpeg)


