### PR TITLE
Remote loop overrides sanitization

### DIFF
--- a/lib/plugins/index.js
+++ b/lib/plugins/index.js
@@ -214,15 +214,15 @@ function init (ctx) {
   plugins.extendedClientSettings = function extendedClientSettings (allExtendedSettings) {
     var clientSettings = {};
     _each(clientDefaultPlugins, function eachClientPlugin (plugin) {
-	  var settings = allExtendedSettings[plugin.name];
-	  if(settings) {
-	    // sanitize private settings
-	    var settingscopy = JSON.parse(JSON.stringify(settings));
-	    delete settingscopy.apnsKey;
-	    delete settingscopy.apnsKeyId;
-	    delete settingscopy.developerTeamId;
+      var settings = allExtendedSettings[plugin.name];
+      if(settings) {
+        // sanitize private settings
+        var settingscopy = JSON.parse(JSON.stringify(settings));
+        delete settingscopy.apnsKey;
+        delete settingscopy.apnsKeyId;
+        delete settingscopy.developerTeamId;
         clientSettings[plugin.name] = settingscopy;
-	  }
+      }
     });
 
     //HACK:  include devicestatus

--- a/lib/plugins/index.js
+++ b/lib/plugins/index.js
@@ -214,7 +214,15 @@ function init (ctx) {
   plugins.extendedClientSettings = function extendedClientSettings (allExtendedSettings) {
     var clientSettings = {};
     _each(clientDefaultPlugins, function eachClientPlugin (plugin) {
-      clientSettings[plugin.name] = allExtendedSettings[plugin.name];
+	  var settings = allExtendedSettings[plugin.name];
+	  if(settings) {
+	    // sanitize private settings
+	    var settingscopy = JSON.parse(JSON.stringify(settings));
+	    delete settingscopy.apnsKey;
+	    delete settingscopy.apnsKeyId;
+	    delete settingscopy.developerTeamId;
+        clientSettings[plugin.name] = settingscopy;
+	  }
     });
 
     //HACK:  include devicestatus

--- a/tests/api.status.sanitized.test.js
+++ b/tests/api.status.sanitized.test.js
@@ -11,9 +11,9 @@ describe('Status REST api sanitization', function ( ) {
   var api = require('../lib/api/');
   beforeEach(function (done) {
     process.env.API_SECRET = 'this is my long pass phrase';
-	process.env.LOOP_APNS_KEY = 'abc123privatekey';
-	process.env.LOOP_APNS_KEY_ID = 'abc123pkid';
-	process.env.LOOP_DEVELOPER_TEAM_ID = 'team123id';
+    process.env.LOOP_APNS_KEY = 'abc123privatekey';
+    process.env.LOOP_APNS_KEY_ID = 'abc123pkid';
+    process.env.LOOP_DEVELOPER_TEAM_ID = 'team123id';
     process.env.ENABLE = ['bridge loop pump iob cob basal careportal sage cage bage openaps override'];
     self.env = require('../env')();
     self.env.settings.authDefaultRoles = 'readable';
@@ -35,14 +35,14 @@ describe('Status REST api sanitization', function ( ) {
       .end(function (err, res)  {
         res.body.apiEnabled.should.equal(true);
         res.body.settings.enable.should.containEql('loop');
-		// do not leak private settings
-		should.not.exist(res.body.extendedSettings.loop.apnsKey);
-		should.not.exist(res.body.extendedSettings.loop.apnsKeyId);
-		should.not.exist(res.body.extendedSettings.loop.developerTeamId);
-	    // do not destroy settings in env
-	    self.env.extendedSettings.loop.apnsKey.should.equal(process.env.LOOP_APNS_KEY);
-	    self.env.extendedSettings.loop.apnsKeyId.should.equal(process.env.LOOP_APNS_KEY_ID);
-	    self.env.extendedSettings.loop.developerTeamId.should.equal(process.env.LOOP_DEVELOPER_TEAM_ID);
+        // do not leak private settings
+        should.not.exist(res.body.extendedSettings.loop.apnsKey);
+        should.not.exist(res.body.extendedSettings.loop.apnsKeyId);
+        should.not.exist(res.body.extendedSettings.loop.developerTeamId);
+        // do not destroy settings in env
+        self.env.extendedSettings.loop.apnsKey.should.equal(process.env.LOOP_APNS_KEY);
+        self.env.extendedSettings.loop.apnsKeyId.should.equal(process.env.LOOP_APNS_KEY_ID);
+        self.env.extendedSettings.loop.developerTeamId.should.equal(process.env.LOOP_DEVELOPER_TEAM_ID);
         done( );
       });
   });

--- a/tests/api.status.sanitized.test.js
+++ b/tests/api.status.sanitized.test.js
@@ -1,0 +1,52 @@
+'use strict';
+
+var request = require('supertest');
+var language = require('../lib/language')();
+
+require('should');
+
+describe('Status REST api sanitization', function ( ) {
+  var self = this;
+
+  var api = require('../lib/api/');
+  beforeEach(function (done) {
+    process.env.API_SECRET = 'this is my long pass phrase';
+	process.env.LOOP_APNS_KEY = 'abc123privatekey';
+	process.env.LOOP_APNS_KEY_ID = 'abc123pkid';
+	process.env.LOOP_DEVELOPER_TEAM_ID = 'team123id';
+    process.env.ENABLE = ['bridge loop pump iob cob basal careportal sage cage bage openaps override'];
+    self.env = require('../env')();
+    self.env.settings.authDefaultRoles = 'readable';
+    this.wares = require('../lib/middleware/')(self.env);
+    self.app = require('express')();
+    self.app.enable('api');
+    require('../lib/server/bootevent')(self.env, language).boot(function booted(ctx) {
+      self.ctx = ctx;
+      self.ctx.ddata = require('../lib/data/ddata')();
+      self.app.use('/api', api(self.env, ctx));
+      done();
+    });
+  });
+
+  it('/status.json', function (done) {
+    request(self.app)
+      .get('/api/status.json')
+      .expect(200)
+      .end(function (err, res)  {
+        res.body.apiEnabled.should.equal(true);
+        res.body.settings.enable.should.containEql('loop');
+		// do not leak private settings
+		should.not.exist(res.body.extendedSettings.loop.apnsKey);
+		should.not.exist(res.body.extendedSettings.loop.apnsKeyId);
+		should.not.exist(res.body.extendedSettings.loop.developerTeamId);
+	    // do not destroy settings in env
+	    self.env.extendedSettings.loop.apnsKey.should.equal(process.env.LOOP_APNS_KEY);
+	    self.env.extendedSettings.loop.apnsKeyId.should.equal(process.env.LOOP_APNS_KEY_ID);
+	    self.env.extendedSettings.loop.developerTeamId.should.equal(process.env.LOOP_DEVELOPER_TEAM_ID);
+        done( );
+      });
+  });
+
+
+});
+


### PR DESCRIPTION
## What
Sanitize extendedClientSettings function output

## Why
Remote override settings require apple keys and IDs to be used that should not be shared publicly

## Notes
This may be a naive approach to solving the issue. My node/js skills are a bit rusty and the JSON parse and unparse is ugly but this seems to be the recommended way to deep copy objects according to my google searches. 